### PR TITLE
[JENKINS-53717] Keep extension point inside the plugin

### DIFF
--- a/src/main/java/io/jenkins/plugins/sprp/YamlBranchProjectFactory.java
+++ b/src/main/java/io/jenkins/plugins/sprp/YamlBranchProjectFactory.java
@@ -32,6 +32,8 @@ import jenkins.scm.api.SCMSourceCriteria;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.multibranch.AbstractWorkflowBranchProjectFactory;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -119,6 +121,7 @@ public class YamlBranchProjectFactory extends AbstractWorkflowBranchProjectFacto
     }
 
     @Extension
+    @Restricted(NoExternalUse.class)
     public static class DescriptorImpl extends AbstractWorkflowBranchProjectFactoryDescriptor {
         @Override
         public String getDisplayName() {

--- a/src/main/java/io/jenkins/plugins/sprp/YamlFlowDefinition.java
+++ b/src/main/java/io/jenkins/plugins/sprp/YamlFlowDefinition.java
@@ -46,6 +46,8 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -131,6 +133,7 @@ public class YamlFlowDefinition extends FlowDefinition {
     }
 
     @Extension
+    @Restricted(NoExternalUse.class)
     public static class DescriptorImpl extends FlowDefinitionDescriptor {
 
         @Nonnull

--- a/src/main/java/io/jenkins/plugins/sprp/YamlMultiBranchProjectFactory.java
+++ b/src/main/java/io/jenkins/plugins/sprp/YamlMultiBranchProjectFactory.java
@@ -31,6 +31,8 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectFactory;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -92,6 +94,7 @@ public class YamlMultiBranchProjectFactory extends WorkflowMultiBranchProjectFac
     }
 
     @Extension
+    @Restricted(NoExternalUse.class)
     public static class DescriptorImpl extends MultiBranchProjectFactoryDescriptor {
 
         @Override

--- a/src/main/java/io/jenkins/plugins/sprp/generators/AgentGenerator.java
+++ b/src/main/java/io/jenkins/plugins/sprp/generators/AgentGenerator.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.sprp.generators;
 import hudson.Extension;
 import io.jenkins.plugins.sprp.models.Agent;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -12,6 +14,7 @@ import java.util.Map;
 
 @Extension
 @Symbol("agent")
+@Restricted(NoExternalUse.class)
 public class AgentGenerator extends PipelineGenerator<Agent> {
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/sprp/generators/ArchiveArtifactStageGenerator.java
+++ b/src/main/java/io/jenkins/plugins/sprp/generators/ArchiveArtifactStageGenerator.java
@@ -2,6 +2,8 @@ package io.jenkins.plugins.sprp.generators;
 
 import hudson.Extension;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -9,6 +11,7 @@ import java.util.List;
 
 @Extension
 @Symbol("archiveArtifactStage")
+@Restricted(NoExternalUse.class)
 public class ArchiveArtifactStageGenerator extends PipelineGenerator<ArrayList<String>> {
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/sprp/generators/CustomSectionGenerator.java
+++ b/src/main/java/io/jenkins/plugins/sprp/generators/CustomSectionGenerator.java
@@ -4,6 +4,8 @@ import hudson.Extension;
 import io.jenkins.plugins.sprp.exception.ConversionException;
 import io.jenkins.plugins.sprp.models.CustomPipelineSection;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -16,6 +18,7 @@ import java.util.List;
  */
 @Extension
 @Symbol("custom")
+@Restricted(NoExternalUse.class)
 public class CustomSectionGenerator extends PipelineGenerator<CustomPipelineSection> {
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/sprp/generators/EnvironmentGenerator.java
+++ b/src/main/java/io/jenkins/plugins/sprp/generators/EnvironmentGenerator.java
@@ -4,6 +4,8 @@ import hudson.Extension;
 import io.jenkins.plugins.sprp.models.Credential;
 import io.jenkins.plugins.sprp.models.Environment;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -12,6 +14,7 @@ import java.util.Map;
 
 @Extension
 @Symbol("environment")
+@Restricted(NoExternalUse.class)
 public class EnvironmentGenerator extends PipelineGenerator<Environment> {
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/sprp/generators/GitPushStageGenerator.java
+++ b/src/main/java/io/jenkins/plugins/sprp/generators/GitPushStageGenerator.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.sprp.generators;
 import hudson.Extension;
 import io.jenkins.plugins.sprp.git.GitConfig;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -10,6 +12,7 @@ import java.util.List;
 
 @Extension
 @Symbol("gitPushStage")
+@Restricted(NoExternalUse.class)
 public class GitPushStageGenerator extends PipelineGenerator<GitConfig> {
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/sprp/generators/PostGenerator.java
+++ b/src/main/java/io/jenkins/plugins/sprp/generators/PostGenerator.java
@@ -5,6 +5,8 @@ import io.jenkins.plugins.sprp.exception.ConversionException;
 import io.jenkins.plugins.sprp.models.Post;
 import io.jenkins.plugins.sprp.models.Step;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -14,6 +16,7 @@ import java.util.Map;
 
 @Extension
 @Symbol("post")
+@Restricted(NoExternalUse.class)
 public class PostGenerator extends PipelineGenerator<Post> {
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/sprp/generators/PublishReportsAndArtifactsStageGenerator.java
+++ b/src/main/java/io/jenkins/plugins/sprp/generators/PublishReportsAndArtifactsStageGenerator.java
@@ -4,6 +4,8 @@ import hudson.Extension;
 import io.jenkins.plugins.sprp.models.ArtifactPublishingConfig;
 import io.jenkins.plugins.sprp.models.ReportsAndArtifactsInfo;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -12,6 +14,7 @@ import java.util.List;
 
 @Extension
 @Symbol("publishReportsAndArtifactsStage")
+@Restricted(NoExternalUse.class)
 public class PublishReportsAndArtifactsStageGenerator extends PipelineGenerator<ReportsAndArtifactsInfo> {
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/sprp/generators/StageGenerator.java
+++ b/src/main/java/io/jenkins/plugins/sprp/generators/StageGenerator.java
@@ -6,6 +6,8 @@ import io.jenkins.plugins.sprp.models.Agent;
 import io.jenkins.plugins.sprp.models.Stage;
 import io.jenkins.plugins.sprp.models.Step;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -15,6 +17,7 @@ import java.util.Map;
 
 @Extension
 @Symbol("stage")
+@Restricted(NoExternalUse.class)
 public class StageGenerator extends PipelineGenerator<Stage> {
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/sprp/generators/StepGenerator.java
+++ b/src/main/java/io/jenkins/plugins/sprp/generators/StepGenerator.java
@@ -15,6 +15,8 @@ import io.jenkins.plugins.sprp.models.Step;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.cps.Snippetizer;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.Constructor;
@@ -25,6 +27,7 @@ import java.util.Map;
 
 @Extension
 @Symbol("step")
+@Restricted(NoExternalUse.class)
 public class StepGenerator extends PipelineGenerator<Step> {
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/sprp/git/GitPushStep.java
+++ b/src/main/java/io/jenkins/plugins/sprp/git/GitPushStep.java
@@ -13,6 +13,8 @@ import hudson.model.queue.Tasks;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.steps.*;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Collections;
@@ -82,6 +84,7 @@ public class GitPushStep extends Step {
 
     @Symbol("gitPush")
     @Extension
+    @Restricted(NoExternalUse.class)
     public static class DescriptorImpl extends StepDescriptor {
         public DescriptorImpl() {
         }


### PR DESCRIPTION
JIRA task: [JENKINS-53717](https://issues.jenkins-ci.org/browse/JENKINS-53717)

As our discussion in Jenkins hackhouse last month, we decided to prevent external use of extension points for this plugin.

@oleg-nenashev @martinda @gautamabhishek46 